### PR TITLE
Modified for compilation with GNU GDC compiler issue with bindbc-sdl thirdparty library

### DIFF
--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlhaptic.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlhaptic.d
@@ -7,7 +7,7 @@
 module bindbc.sdl.bind.sdlhaptic;
 
 import bindbc.sdl.config;
-import bindbc.sdl.bind.sdljoystick : SDL_Joystick;
+import bindbc.sdl.bind.sdljoystick;
 
 struct SDL_Haptic;
 

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlkeyboard.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlkeyboard.d
@@ -11,7 +11,7 @@ import bindbc.sdl.bind.sdlkeycode : SDL_Keycode, SDL_Keymod;
 import bindbc.sdl.bind.sdlrect : SDL_Rect;
 import bindbc.sdl.bind.sdlscancode : SDL_Scancode;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 
 struct SDL_Keysym {
     SDL_Scancode scancode;

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlmessagebox.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlmessagebox.d
@@ -7,7 +7,7 @@
 module bindbc.sdl.bind.sdlmessagebox;
 
 import bindbc.sdl.config;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 
 // SDL_MessageBoxFlags
 enum SDL_MESSAGEBOX_ERROR = 0x00000010;

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlmouse.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlmouse.d
@@ -9,7 +9,7 @@ module bindbc.sdl.bind.sdlmouse;
 import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 import bindbc.sdl.bind.sdlsurface : SDL_Surface;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 
 struct SDL_Cursor;
 

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlrender.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlrender.d
@@ -11,7 +11,7 @@ import bindbc.sdl.bind.sdlblendmode : SDL_BlendMode;
 import bindbc.sdl.bind.sdlrect;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 import bindbc.sdl.bind.sdlsurface : SDL_Surface;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 import bindbc.sdl.bind.sdlpixels : SDL_Color;
 
 enum : uint {

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlshape.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlshape.d
@@ -10,7 +10,7 @@ import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlpixels : SDL_Color;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 import bindbc.sdl.bind.sdlsurface : SDL_Surface;
-import bindbc.sdl.bind.sdlvideo : SDL_Window, SDL_WindowFlags;
+import bindbc.sdl.bind.sdlvideo;
 
 enum {
     SDL_NONSHAPEABLE_WINDOW = -1,

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlsystem.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlsystem.d
@@ -7,7 +7,7 @@
 module bindbc.sdl.bind.sdlsystem;
 
 import bindbc.sdl.config;
-import bindbc.sdl.bind.sdlrender : SDL_Renderer;
+import bindbc.sdl.bind.sdlrender;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 
 version(Android) {

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlsyswm.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlsyswm.d
@@ -10,7 +10,7 @@ import core.stdc.config : c_long;
 import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
 import bindbc.sdl.bind.sdlversion : SDL_version;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 
 
 static if(sdlSupport >= SDLSupport.sdl2012) {

--- a/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlvulkan.d
+++ b/thirdparty/bindbc-sdl-1.1.2/source/bindbc/sdl/bind/sdlvulkan.d
@@ -8,7 +8,7 @@ module bindbc.sdl.bind.sdlvulkan;
 
 import bindbc.sdl.config;
 import bindbc.sdl.bind.sdlstdinc : SDL_bool;
-import bindbc.sdl.bind.sdlvideo : SDL_Window;
+import bindbc.sdl.bind.sdlvideo;
 
 static if(staticBinding) {
     extern(C) @nogc nothrow {


### PR DESCRIPTION
Description:
Modified imports to avoid compilation issue:
    at bindbc/sdl/bind/sdlhaptic.d:10:8: internal compiler error: in make_import, at d/imports.cc:48

Note:
Not sure what causing this issue, possibly this issue will be resolved in future.

Fix:
     Workaround: for failing import use regular (non specific) import for all conponents available. They still seems to be supported in GNU but these cases are failing. This fix doesn't change any logic of code.


