### PR TITLE
Removed warnings of deprecated log2 method call 

### DIFF
--- a/src/dagon/graphics/texture.d
+++ b/src/dagon/graphics/texture.d
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 */
 module dagon.graphics.texture;
 
+import std.conv;
 import std.stdio;
 import std.math;
 import std.algorithm;
@@ -525,7 +526,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_1D);
-                    mipLevels = 1 + cast(uint)floor(log2(w));
+                    mipLevels = 1 + cast(uint)floor(log2(w.to!float));
                 }
                 else
                     mipLevels = 1;
@@ -580,7 +581,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_2D);
-                    mipLevels = 1 + cast(uint)floor(log2(max(w, h)));
+                    mipLevels = 1 + cast(uint)floor(log2(max(w, h).to!float));
                 }
                 else
                     mipLevels = 1;
@@ -650,7 +651,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_3D);
-                    mipLevels = 1 + cast(uint)floor(log2(max3(w, h, d)));
+                    mipLevels = 1 + cast(uint)floor(log2(max3(w, h, d).to!float));
                 }
                 else
                     mipLevels = 1;
@@ -722,7 +723,7 @@ class Texture: Owner
             if (generateMipmaps)
             {
                 glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
-                mipLevels = 1 + cast(uint)floor(log2(resolution));
+                mipLevels = 1 + cast(uint)floor(log2(resolution.to!float));
             }
             else
                 mipLevels = 1;
@@ -741,7 +742,7 @@ class Texture: Owner
         {
             bind();
             glGenerateMipmap(format.target);
-            mipLevels = 1 + cast(uint)floor(log2(max(size.width, size.height)));
+            mipLevels = 1 + cast(uint)floor(log2(max(size.width, size.height).to!float));
             unbind();
             useMipmapFiltering(true);
         }


### PR DESCRIPTION
Removed warnings of deprecated method call like below: 

src/dagon/graphics/texture.d:528:57: warning: function ‘std.math.exponential.log2’ is deprecated - `std.math.exponential.log2` called with argument types `(uint)` matches both `log2(real)`, `log2(double)`, and `log2(float)`. Cast argument to floating point type instead. [-Wdeprecated]

Fix:
Used explicit type cast instead